### PR TITLE
add "check root" option

### DIFF
--- a/dotgit.js
+++ b/dotgit.js
@@ -174,7 +174,7 @@ async function fetchWithTimeout(resource, options) {
 }
 
 async function checkGit(url) {
-    const to_check = (url + GIT_HEAD_PATH).replace(/\/\//g ,'/');
+    const to_check = (url + GIT_HEAD_PATH).replace(/\/\//g, '/');
     const search = new RegExp(GIT_OBJECTS_SEARCH, "y");
 
     try {
@@ -631,9 +631,9 @@ chrome.storage.local.get(["checked", "withExposedGit", "options"], function (res
             if (check_root) {
                 candidates.unshift(url.origin + '/');
             }
-            
+
             candidates.forEach((candidate) => {
-                if(checkUrl(storage, candidate)) processSearch(storage, candidate);
+                if (checkUrl(storage, candidate)) processSearch(storage, candidate);
             });
         });
     }, {urls: ["<all_urls>"]});
@@ -647,9 +647,9 @@ chrome.storage.local.set({
 
 function checkUrl(storage, origin) {
     if (origin[origin.length - 1] !== '/') return false;
-    
+
     let hostname = new URL(origin)["hostname"];
-    
+
     // replace ws and wss with http and https
     origin = origin.replace(WS_SEARCH, WS_REPLACE);
 

--- a/dotgit.js
+++ b/dotgit.js
@@ -89,7 +89,7 @@ const GIT_WELL_KNOW_PATHS = [
     "info/exclude"
 ];
 
-const EXTENSION_URL = chrome.runtime.getURL('').replace(/\/$/, '');
+const EXTENSION_URL = chrome.runtime.getURL('');
 
 let wait;
 let max_wait;
@@ -622,7 +622,8 @@ chrome.storage.local.get(["checked", "withExposedGit", "options"], function (res
     chrome.webRequest.onCompleted.addListener(async (details) => {
         chrome.storage.local.get(["checked", "withExposedGit"], storage => {
             // Drop requests done by the extension itself, prevent endless loop
-            if (details.initiator === EXTENSION_URL) return;
+            if (details.originUrl + '_generated_background_page.html' === EXTENSION_URL ||
+                details.initiator + '/' === EXTENSION_URL) return;
 
             let url = new URL(details.url);
             let candidates = [url.origin + url.pathname.replace(/\/[^/]+$/, '/')];

--- a/dotgit.js
+++ b/dotgit.js
@@ -89,7 +89,7 @@ const GIT_WELL_KNOW_PATHS = [
     "info/exclude"
 ];
 
-const EXTENSION_URL = chrome.extension.getURL('').replace(/\/$/, '');
+const EXTENSION_URL = chrome.runtime.getURL('').replace(/\/$/, '');
 
 let wait;
 let max_wait;

--- a/dotgit.js
+++ b/dotgit.js
@@ -13,6 +13,7 @@ const DEFAULT_OPTIONS = {
     },
     "check_opensource": true,
     "check_securitytxt": true,
+    "check_root": true,
     "download": {
         "wait": 100,
         "max_wait": 10000,
@@ -88,19 +89,21 @@ const GIT_WELL_KNOW_PATHS = [
     "info/exclude"
 ];
 
+const EXTENSION_URL = chrome.extension.getURL('').replace(/\/$/, '');
+
 let wait;
 let max_wait;
 let max_connections;
 let notification_new_git;
 let notification_download;
 let check_opensource;
+let check_root;
 let check_securitytxt;
 let check_git;
 let check_svn;
 let check_hg;
 let check_env;
 let failed_in_a_row;
-let queue_listener = new Queue();
 let queue_req = new Queue();
 let queue_running = false;
 let blacklist = [];
@@ -172,7 +175,7 @@ async function fetchWithTimeout(resource, options) {
 
 
 async function checkGit(url) {
-    const to_check = url + GIT_HEAD_PATH;
+    const to_check = (url + GIT_HEAD_PATH).replace(/\/\//g ,'/');
     const search = new RegExp(GIT_OBJECTS_SEARCH, "y");
 
     try {
@@ -485,6 +488,7 @@ function set_options(options) {
     notification_download = options.notification.download;
     check_opensource = options.check_opensource;
     check_securitytxt = options.check_securitytxt;
+    check_root = options.check_root;
     check_git = options.functions.git;
     check_svn = options.functions.svn;
     check_hg = options.functions.hg;
@@ -559,6 +563,9 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     } else if (request.type === "check_securitytxt") {
         check_securitytxt = request.value;
         sendResponse({status: true});
+    } else if (request.type === "check_root") {
+        check_root = request.value;
+        sendResponse({status: true});
     } else if (request.type === "blacklist") {
         blacklist = request.value;
         sendResponse({status: true});
@@ -613,7 +620,23 @@ chrome.storage.local.get(["checked", "withExposedGit", "options"], function (res
 
     set_options(result.options);
 
-    chrome.webRequest.onCompleted.addListener(details => processListener(details), {urls: ["<all_urls>"]});
+    chrome.webRequest.onCompleted.addListener((details) => {
+        chrome.storage.local.get(["checked", "withExposedGit"], storage => {
+            // Drop requests done by the extension itself, prevent endless loop
+            if (details.initiator === EXTENSION_URL) return;
+
+            let url = new URL(details.url);
+            let candidates = [url.origin + url.pathname];
+
+            if (check_root) {
+                candidates.unshift(url.origin + '/');
+            }
+            
+            candidates.forEach((candidate) => {
+                if(checkUrl(storage, candidate)) processSearch(storage, candidate);
+            });
+        });
+    }, {urls: ["<all_urls>"]});
 });
 
 // Reset download status at each start
@@ -622,44 +645,29 @@ chrome.storage.local.set({
 });
 
 
-function processListener(details) {
-    let origin = new URL(details["url"])["origin"];
-    if (queue_req.isEmpty() === true) {
-        chrome.storage.local.get(["checked", "withExposedGit"], result => processSearch(result, origin));
-    } else {
-        queue_listener.enqueue(origin);
-    }
-}
-
-
 function checkUrl(storage, origin) {
+    if (origin[origin.length - 1] !== '/') return false;
+    
     let hostname = new URL(origin)["hostname"];
+    
     // replace ws and wss with http and https
     origin = origin.replace(WS_SEARCH, WS_REPLACE);
 
     if (origin.startsWith("chrome-extension")) {
         return false;
     }
+
     return (storage.checked.includes(origin) === false && checkBlacklist(hostname) === false);
 }
 
 
 async function processSearch(storage, origin) {
-    if (checkUrl(storage, origin)) {
-        if (queue_running === false) {
-            queue_running = true;
-            queue_req.enqueue(origin);
-            while (queue_listener.isEmpty() === false) {
-                let origin2 = queue_listener.dequeue();
-                if (checkUrl(storage, origin2)) {
-                    queue_req.enqueue(origin2);
-                }
-            }
-            await precessQueue(storage);
-            queue_running = false;
-        } else {
-            queue_listener.enqueue(origin);
-        }
+    queue_req.enqueue(origin);
+
+    if (queue_running === false) {
+        queue_running = true;
+        await precessQueue(storage);
+        queue_running = false;
     }
 }
 

--- a/dotgit.js
+++ b/dotgit.js
@@ -173,7 +173,6 @@ async function fetchWithTimeout(resource, options) {
     return response;
 }
 
-
 async function checkGit(url) {
     const to_check = (url + GIT_HEAD_PATH).replace(/\/\//g ,'/');
     const search = new RegExp(GIT_OBJECTS_SEARCH, "y");
@@ -620,13 +619,13 @@ chrome.storage.local.get(["checked", "withExposedGit", "options"], function (res
 
     set_options(result.options);
 
-    chrome.webRequest.onCompleted.addListener((details) => {
+    chrome.webRequest.onCompleted.addListener(async (details) => {
         chrome.storage.local.get(["checked", "withExposedGit"], storage => {
             // Drop requests done by the extension itself, prevent endless loop
             if (details.initiator === EXTENSION_URL) return;
 
             let url = new URL(details.url);
-            let candidates = [url.origin + url.pathname];
+            let candidates = [url.origin + url.pathname.replace(/\/[^/]+$/, '/')];
 
             if (check_root) {
                 candidates.unshift(url.origin + '/');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "DotGit",
-  "version": "4.6.6",
+  "version": "4.7",
   "description": "An extension for checking if .git is exposed in visited websites",
   "icons": {
     "16": "icons/dotgit-16.png",

--- a/options/options.html
+++ b/options/options.html
@@ -113,6 +113,19 @@
     </div>
 </section>
 <section class="option">
+    <div class="browser-style">
+        Check .git on URL root (checks only current relative path by default)<br>
+    </div>
+    <div class="browser-style title-option">
+        Check .git root
+        <input type="radio" id="on5" name="check_root" value="on" checked/>
+        <label for="on5">On</label>
+
+        <input type="radio" id="off5" name="check_root" value="off"/>
+        <label for="off5">Off</label>
+    </div>
+</section>
+<section class="option">
     <div class="browser-style title-option">
         Blacklist hostname (comma separated and supports wildcards)<br>
     </div>

--- a/options/options.js
+++ b/options/options.js
@@ -26,6 +26,8 @@ function set_gui(options) {
     document.getElementById("off3").checked = !options.check_opensource;
     document.getElementById("on4").checked = options.check_securitytxt;
     document.getElementById("off4").checked = !options.check_securitytxt;
+    document.getElementById("on5").checked = options.check_root;
+    document.getElementById("off5").checked = !options.check_root;
     document.getElementById("blacklist").value = options.blacklist.join(", ");
 }
 
@@ -102,6 +104,14 @@ document.addEventListener("DOMContentLoaded", function () {
                 chrome.runtime.sendMessage({
                     type: e.target.name,
                     value: result.options.check_securitytxt
+                }, function (response) {
+                });
+            } else if (e.target.name === "check_root") {
+                result.options.check_root = (e.target.value === "on");
+                chrome.storage.local.set(result);
+                chrome.runtime.sendMessage({
+                    type: e.target.name,
+                    value: result.options.check_root
                 }, function (response) {
                 });
             } else if (e.target.validity.valid === true && (e.target.id === "max_connections" || e.target.id === "wait" || e.target.id === "max_wait" || e.target.id === "failed_in_a_row")) {

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -32,3 +32,41 @@ ul.collection {
     height: auto;
     color: black;
 }
+
+#storage {
+    position: relative;
+    height: 24px;
+    width: 100%;
+    background-color: #5a5a5a;
+}
+
+#storage .usage-bar {
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    background-color: rgb(29, 192, 29);
+    min-width: 3px;
+}
+
+#storage .usage {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    color: white;
+    font-size: 12px;
+    text-align: center;
+    line-height: 25px;
+}
+
+#storage .usage-bar.medium {
+    background-color: rgb(233, 152, 32);
+}
+
+#storage .usage-bar.severe {
+    background-color: rgb(218, 59, 31);
+}

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -17,10 +17,14 @@
         <ul class="right">
             <li><a><i class="material-icons" title="About" id="about">info</i></a></li>
             <li><a><i class="material-icons" title="Settings" id="options">settings</i></a></li>
-            <li><a><i class="material-icons" title="Delete all" id="reset">delete_forever</i></a></li>
+            <li><a><i class="material-icons" title="Delete findings" id="reset">delete_forever</i></a></li>
         </ul>
     </div>
 </nav>
+<div id="storage" class="z-depth-1">
+    <div class="usage-bar"></div>
+    <div class="usage"></div>
+</div>
 <ul class="collection" id="hostsFound">
     <li class="collection-item center" id="hostsFoundTitle">Total found: 0 Max shown: 100</li>
 </ul>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -11,7 +11,7 @@ if (chrome.browserAction.setBadgeText) {
 
 function formatBytes(size) {
     const i = Math.floor(Math.log(size) / Math.log(1024));
-    
+
     return (size / Math.pow(1024, i)).toFixed(2)
         * 1 // Remove eventual zero at the end
         + ['B', 'kB', 'MB', 'GB', 'TB'][i];
@@ -24,7 +24,7 @@ function updateStorageIndicator() {
     const quota = chrome.storage.local.QUOTA_BYTES;
 
     chrome.storage.local.getBytesInUse(null, function (memUsage) {
-        let percent = ((memUsage/quota)*100).toFixed(2);
+        let percent = ((memUsage / quota) * 100).toFixed(2);
         storageUsageBar.style.width = percent + '%';
         storageUsageBar.classList.remove('medium', 'high');
         if (percent > 40) storageUsageBar.classList.add(percent > 70 ? 'high' : 'medium');

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -9,17 +9,45 @@ if (chrome.browserAction.setBadgeText) {
     });
 }
 
+function formatBytes(size) {
+    const i = Math.floor(Math.log(size) / Math.log(1024));
+    
+    return (size / Math.pow(1024, i)).toFixed(2)
+        * 1 // Remove eventual zero at the end
+        + ['B', 'kB', 'MB', 'GB', 'TB'][i];
+};
+
+function updateStorageIndicator() {
+    const storage = document.querySelector('#storage');
+    const storageUsageBar = storage.querySelector('.usage-bar');
+    const storageUsage = storage.querySelector('.usage');
+    const quota = chrome.storage.local.QUOTA_BYTES;
+
+    chrome.storage.local.getBytesInUse(null, function (memUsage) {
+        let percent = ((memUsage/quota)*100).toFixed(2);
+        storageUsageBar.style.width = percent + '%';
+        storageUsageBar.classList.remove('medium', 'high');
+        if (percent > 40) storageUsageBar.classList.add(percent > 70 ? 'high' : 'medium');
+        storageUsage.innerText = '' + formatBytes(memUsage) + '/' + formatBytes(quota) + ' - ' + percent + '%';
+    });
+}
 
 document.addEventListener("DOMContentLoaded", function () {
-    chrome.storage.local.get(["options"], function (options) {
-        let color = options.options.color;
+    chrome.storage.local.get(["options", "withExposedGit"], async function (local) {
+        let color = local.options.color;
         let list = document.getElementsByClassName("custom-color");
         for (let n = 0; n < list.length; ++n) {
             list[n].className += " " + color;
         }
-        let max_sites = options.options.max_sites
+        let max_sites = local.options.max_sites
         let hostElementFoundTitle = document.getElementById("hostsFoundTitle");
-        hostElementFoundTitle.textContent = "Total found: 0 Max shown: " + max_sites;
+        hostElementFoundTitle.textContent = "Total found: " + local.withExposedGit.length + " Max shown: " + max_sites;
+
+        updateStorageIndicator();
+    });
+
+    chrome.storage.local.onChanged.addListener(() => {
+        updateStorageIndicator();
     });
 });
 


### PR DESCRIPTION
## Assessment
Current behavior is to check URL root for each HTTP response received by the browser. Problem with this is that we cannot detect exposed .env (for example) if it's not located at the document root of the webserver.

## Solution
This commits enables DotGit to check two locations for each HTTP response :
- URL root
- URL root + path

By default, both of these locations are checked.

An option has been introduced to prevent DotGit from checking URL root automatically.

## Improvements
Allow to check every directory in the full URL's path (ie. `/project/git/foo` > `/project/git/foo`, `/project/git`, `/project`, `/`).