### PR TITLE
Add a parser/browser for .DS_Store files

### DIFF
--- a/popup/dsstore_parser.js
+++ b/popup/dsstore_parser.js
@@ -76,7 +76,7 @@ function valueDataSize(vt, atPos, buffer, view) {
         case 'long':
             return 4;
         case 'shor':
-            return 2;
+            return 4;
         case 'ustr': {
             if (atPos + 4 > buffer.byteLength) throw new TypeError('ustr length read out of range');
             const charCount = view.getUint32(atPos, false);
@@ -152,12 +152,14 @@ function traverseNode(blockId, blockAddrs, blockCount, buffer, view, bytes, file
     traverseNode(firstChild, blockAddrs, blockCount, buffer, view, bytes, filenames, visited);
 
     for (let i = 0; i < count; i++) {
-        const next = readRecord(p, buffer, view, bytes, filenames);
-        if (next + 4 > blockEnd) throw new TypeError('Internal node child pointer out of range');
-        p = next;
-
+        if (p + 4 > blockEnd) throw new TypeError('Internal node child pointer out of range');
         const childId = view.getUint32(p, false);
         p += 4;
+
+        const next = readRecord(p, buffer, view, bytes, filenames);
+        if (next > blockEnd) throw new TypeError('Internal node record exceeds block boundary');
+        p = next;
+
         traverseNode(childId, blockAddrs, blockCount, buffer, view, bytes, filenames, visited);
     }
 }

--- a/popup/dsstore_parser.js
+++ b/popup/dsstore_parser.js
@@ -1,0 +1,267 @@
+// popup/dsstore_parser.js
+// Parses Apple's .DS_Store binary format (Buddy Allocator + B-tree).
+// Returns a sorted array of unique filename strings found in the .DS_Store,
+// or throws an Error with a descriptive message if the file is invalid.
+//
+// Format reference: Mark Mentovai's reverse-engineering notes (https://wiki.mozilla.org/DS_Store_File_Format).
+
+function readU32(pos, buffer, view) {
+    if (pos + 4 > buffer.byteLength) throw new TypeError('RU32: Unexpected end of file at 0x' + pos.toString(16));
+    const v = view.getUint32(pos, false);
+    return { value: v, pos: pos + 4 };
+}
+
+function readU16(pos, buffer, view) {
+    if (pos + 2 > buffer.byteLength) throw new TypeError('RU16: Unexpected end of file at 0x' + pos.toString(16));
+    const v = view.getUint16(pos, false);
+    return { value: v, pos: pos + 2 };
+}
+
+function readU8(pos, buffer, bytes) {
+    if (pos >= buffer.byteLength) throw new TypeError('RU8: Unexpected end of file at 0x' + pos.toString(16));
+    return { value: bytes[pos], pos: pos + 1 };
+}
+
+function readAscii(pos, len, buffer, bytes) {
+    if (pos + len > buffer.byteLength) throw new TypeError('ASCII: Unexpected end of file at 0x' + pos.toString(16));
+    let s = '';
+    for (let i = 0; i < len; i++) {
+        s += String.fromCodePoint(bytes[pos + i]);
+    }
+    return { value: s, pos: pos + len };
+}
+
+function readUtf16beString(pos, charCount, buffer, view) {
+    if (pos + charCount * 2 > buffer.byteLength) throw new TypeError('UTF16: Unexpected end of file at 0x' + pos.toString(16));
+    let s = '';
+    for (let i = 0; i < charCount; i++) {
+        s += String.fromCodePoint(view.getUint16(pos + i * 2, false));
+    }
+    return { value: s, pos: pos + charCount * 2 };
+}
+
+function decodeBlockOffset(rawAddr) {
+    return (rawAddr & ~0x1F) + 4;
+}
+
+function decodeBlockSize(rawAddr) {
+    return 1 << (rawAddr & 0x1F);
+}
+
+function getBlockInfo(blockId, blockAddrs, blockCount, buffer) {
+    if (blockId < 0 || blockId >= blockCount) {
+        throw new TypeError('Block ID ' + blockId + ' out of range');
+    }
+
+    const rawAddr = blockAddrs[blockId];
+    const offset = decodeBlockOffset(rawAddr);
+    const size = decodeBlockSize(rawAddr);
+
+    if (offset < 0 || offset + size > buffer.byteLength) {
+        throw new TypeError('Decoded block ' + blockId + ' out of range (offset 0x' + offset.toString(16) + ', size ' + size + ')');
+    }
+
+    return { offset, size, rawAddr };
+}
+
+function valueDataSize(vt, atPos, buffer, view) {
+    switch (vt) {
+        case 'blob': {
+            if (atPos + 4 > buffer.byteLength) throw new TypeError('blob length read out of range');
+            const len = view.getUint32(atPos, false);
+            return 4 + len;
+        }
+        case 'bool':
+            return 1;
+        case 'long':
+            return 4;
+        case 'shor':
+            return 2;
+        case 'ustr': {
+            if (atPos + 4 > buffer.byteLength) throw new TypeError('ustr length read out of range');
+            const charCount = view.getUint32(atPos, false);
+            return 4 + charCount * 2;
+        }
+        case 'type':
+            return 4;
+        case 'comp':
+            return 8;
+        case 'dutc':
+            return 8;
+        default:
+            throw new TypeError('Unknown DS_Store value type: "' + vt + '"');
+    }
+}
+
+function readRecord(pos, buffer, view, bytes, filenames) {
+    let result = readU32(pos, buffer, view);
+    const fnLen = result.value;
+    pos = result.pos;
+
+    result = readUtf16beString(pos, fnLen, buffer, view);
+    const filename = result.value;
+    pos = result.pos;
+    filenames.add(filename);
+
+    if (pos + 4 > buffer.byteLength) throw new TypeError('Record structure type out of range');
+    pos += 4;
+
+    result = readAscii(pos, 4, buffer, bytes);
+    const vt = result.value;
+    pos = result.pos;
+
+    const skip = valueDataSize(vt, pos, buffer, view);
+    if (pos + skip > buffer.byteLength) throw new TypeError('Value data out of range for type "' + vt + '"');
+    pos += skip;
+
+    return pos;
+}
+
+function traverseNode(blockId, blockAddrs, blockCount, buffer, view, bytes, filenames, visited) {
+    if (blockId < 0 || blockId >= blockCount) {
+        throw new TypeError('B-tree node block ID ' + blockId + ' out of range');
+    }
+
+    if (visited.has(blockId)) return;
+    visited.add(blockId);
+
+    const block = getBlockInfo(blockId, blockAddrs, blockCount, buffer);
+    let p = block.offset;
+    const blockEnd = block.offset + block.size;
+
+    if (p + 8 > blockEnd) {
+        throw new TypeError('B-tree node header out of range for block ' + blockId);
+    }
+
+    const mode = view.getUint32(p, false);
+    const count = view.getUint32(p + 4, false);
+    p += 8;
+
+    const isLeaf = (mode === 0);
+
+    if (isLeaf) {
+        for (let i = 0; i < count; i++) {
+            const next = readRecord(p, buffer, view, bytes, filenames);
+            if (next > blockEnd) throw new TypeError('Leaf record exceeds block boundary');
+            p = next;
+        }
+        return;
+    }
+
+    const firstChild = mode;
+    traverseNode(firstChild, blockAddrs, blockCount, buffer, view, bytes, filenames, visited);
+
+    for (let i = 0; i < count; i++) {
+        const next = readRecord(p, buffer, view, bytes, filenames);
+        if (next + 4 > blockEnd) throw new TypeError('Internal node child pointer out of range');
+        p = next;
+
+        const childId = view.getUint32(p, false);
+        p += 4;
+        traverseNode(childId, blockAddrs, blockCount, buffer, view, bytes, filenames, visited);
+    }
+}
+
+function parseDSStore(buffer) {
+    if (!(buffer instanceof ArrayBuffer)) {
+        throw new TypeError('DS_Store parser received an invalid datatype (expected ArrayBuffer)');
+    }
+    if (buffer.byteLength < 36) {
+        throw new TypeError('.DS_Store file length exception.');
+    }
+
+    const view  = new DataView(buffer);
+    const bytes = new Uint8Array(buffer);
+
+    if (view.getUint32(0, false) !== 0x00000001) {
+        throw new TypeError('Invalid .DS_Store magic (expected 0x00000001)');
+    }
+
+    const bud1 = String.fromCodePoint(bytes[4], bytes[5], bytes[6], bytes[7]);
+    if (bud1 !== 'Bud1') {
+        throw new TypeError('Invalid .DS_Store magic (expected "Bud1", got "' + bud1 + '")');
+    }
+
+    const allocatorOffsetA = view.getUint32(0x08, false);
+    const allocatorSize = view.getUint32(0x0C, false);
+    const allocatorOffsetB = view.getUint32(0x10, false);
+
+    if (allocatorOffsetA !== allocatorOffsetB) {
+        throw new TypeError('Allocator offset copies do not match');
+    }
+
+    const rootOffset = allocatorOffsetA + 4;
+    if (rootOffset >= buffer.byteLength) {
+        throw new TypeError('Root block offset out of range: ' + rootOffset);
+    }
+    if (rootOffset + allocatorSize > buffer.byteLength) {
+        throw new TypeError('Allocator bookkeeping block out of range');
+    }
+
+    let pos = rootOffset;
+
+    let result = readU32(pos, buffer, view);
+    const blockCount = result.value;
+    pos = result.pos + 4;
+
+    const blockAddrs = new Uint32Array(blockCount);
+    for (let i = 0; i < blockCount; i++) {
+        result = readU32(pos, buffer, view);
+        blockAddrs[i] = result.value;
+        pos = result.pos;
+    }
+
+    pos = rootOffset + 8 + (256 * 4);
+    if (pos + 4 > buffer.byteLength) {
+        throw new TypeError('Allocator directory header out of range');
+    }
+
+    result = readU32(pos, buffer, view);
+    const dirCount = result.value;
+    pos = result.pos;
+
+    let dsdbBlockId = -1;
+    for (let d = 0; d < dirCount; d++) {
+        let r8 = readU8(pos, buffer, bytes);
+        const nameLen = r8.value;
+        pos = r8.pos;
+
+        let nameResult = readAscii(pos, nameLen, buffer, bytes);
+        const name = nameResult.value;
+        pos = nameResult.pos;
+
+        result = readU32(pos, buffer, view);
+        const blockId = result.value;
+        pos = result.pos;
+
+        if (name === 'DSDB') {
+            dsdbBlockId = blockId;
+        }
+    }
+
+    if (dsdbBlockId === -1) {
+        throw new TypeError('No directory entry header found in allocator block');
+    }
+    if (dsdbBlockId >= blockCount) {
+        throw new TypeError('DSDB block ID ' + dsdbBlockId + ' out of range (block count: ' + blockCount + ')');
+    }
+
+    const masterBlock = getBlockInfo(dsdbBlockId, blockAddrs, blockCount, buffer);
+    if (masterBlock.size < 20) {
+        throw new TypeError('DSDB master block too small');
+    }
+
+    const rootNodeBlockId = view.getUint32(masterBlock.offset, false);
+    if (rootNodeBlockId >= blockCount) {
+        throw new TypeError('Root node block ID ' + rootNodeBlockId + ' out of range');
+    }
+
+    const filenames = new Set();
+    const visited = new Set();
+
+    traverseNode(rootNodeBlockId, blockAddrs, blockCount, buffer, view, bytes, filenames, visited);
+
+    return Array.from(filenames)
+        .filter(f => f !== '.')
+        .sort((a, b) => a.localeCompare(b));
+}

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -33,3 +33,90 @@ ul.collection {
     height: auto;
     color: black;
 }
+
+/* ── DS_Store Browser Overlay ─────────────────────────────────────────────── */
+
+#dss-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    background: white;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+#dss-overlay nav {
+    flex-shrink: 0;
+}
+
+#dss-path {
+    max-width: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline-block;
+    vertical-align: middle;
+    line-height: 56px;
+    font-size: 0.8rem;
+    font-weight: bold;
+    color: white;
+}
+
+#dss-back,
+#dss-close {
+    cursor: pointer;
+}
+
+
+#dss-overlay ul.collection {
+    flex: 1;
+    overflow-y: auto;
+    margin: 7px;
+    max-height: none;
+}
+
+.dss-entry {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    word-break: break-all;
+}
+
+.dss-entry .material-icons {
+    font-size: 18px;
+    margin-right: 6px;
+    flex-shrink: 0;
+}
+
+/* Browsable directory - shown in blue, clickable */
+.dss-browsable {
+    color: #1565C0;
+}
+
+.dss-browsable .material-icons {
+    color: #1565C0;
+}
+
+/* Non-browsable entry (file or directory without nested .DS_Store) - grey */
+.dss-grey {
+    color: #9E9E9E;
+    cursor: default;
+}
+
+.dss-grey a {
+    color: #9E9E9E;
+}
+
+.dss-grey .material-icons {
+    color: #BDBDBD;
+}
+
+/* While probing - dim italic */
+.dss-loading {
+    color: #BDBDBD;
+    font-style: italic;
+}

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -79,6 +79,13 @@ ul.collection {
     max-height: none;
 }
 
+#dss-note {
+    flex-shrink: 0;
+    padding: 0 12px 12px;
+    color: #757575;
+    font-size: 0.85rem;
+}
+
 .dss-entry {
     display: flex;
     align-items: center;

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="icon.css">
     <link rel="stylesheet" href="popup.css"/>
     <base target="_blank">
+    <script src="dsstore_parser.js"></script>
     <script src="popup.js"></script>
 </head>
 <body class="darken-3 custom-color">
@@ -28,5 +29,21 @@
 <ul class="collection" id="hostsFound">
     <li class="collection-item center" id="hostsFoundTitle">Total found: 0 Max shown: 100</li>
 </ul>
+<!-- .DS_Store Browser -->
+<div id="dss-overlay" style="display:none;">
+    <nav id="dss-nav">
+        <div class="nav-wrapper darken-3 custom-color">
+            <ul class="left">
+                <li id="dss-back-li" style="display:none"><a><i class="material-icons" id="dss-back" title="Go back">arrow_back</i></a></li>
+            </ul>
+            <span class="brand-logo truncate" id="dss-path" title=""></span>
+            <ul class="right">
+                <li><a><i class="material-icons" id="dss-close" title="Close">close</i></a></li>
+            </ul>
+        </div>
+    </nav>
+    <ul class="collection" id="dss-list"></ul>
+    <div id="dss-status" class="center" style="display:none; padding: 12px;">Loading...</div>
+</div>
 </body>
 </html>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -44,6 +44,9 @@
     </nav>
     <ul class="collection" id="dss-list"></ul>
     <div id="dss-status" class="center" style="display:none; padding: 12px;">Loading...</div>
+    <div id="dss-note" class="center">
+        .DS_Store reflects macOS Finder metadata only. Some files may be absent even when they exist on the server.
+    </div>
 </div>
 </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -156,6 +156,16 @@ function addElements(element, array, callback, downloading, max_sites) {
             link.setAttribute("href", HREF_PREFIX + callback(array[i].url) + "/.env");
         }
         if (callback(array[i].type) === "ds_store") {
+            const spanBrowse = document.createElement("span");
+            spanBrowse.setAttribute("class", "secondary-content");
+            const btnBrowse = document.createElement("i");
+            btnBrowse.setAttribute("id", "dsbrowse:" + callback(array[i].url));
+            btnBrowse.setAttribute("class", "material-icons btn-small green browse-dsstore");
+            btnBrowse.setAttribute("title", "Browse .DS_Store file listing");
+            btnBrowse.innerText = "folder_open";
+            spanBrowse.appendChild(btnBrowse);
+            listItem.appendChild(spanBrowse);
+
             if (callback(array[i].securitytxt) !== "false" && callback(array[i].securitytxt) !== "undefined") {
                 listItem.appendChild(spanSecuritytxtStatus);
             }
@@ -236,6 +246,13 @@ document.addEventListener("click", async (event) => {
                 });
             }
         });
+    } else if (button.classList.contains("browse-dsstore")) {
+        const url = button.id.substring("dsbrowse:".length);
+        openDsStoreBrowser(url);
+    } else if (button.id === "dss-back") {
+        dssNavigateBack();
+    } else if (button.id === "dss-close") {
+        dssClose();
     } else if (button.id === "options") {
         if (chrome.runtime.openOptionsPage) {
             chrome.runtime.openOptionsPage();
@@ -368,3 +385,218 @@ document.addEventListener("DOMContentLoaded", async function () {
         hostElementFoundTitle.textContent = "Total found: 0 Max shown: " + max_sites;
     });
 });
+
+
+// ── DS_Store Browser Panel ─────────────────────────────────────────────────
+//
+// Navigation stack: array of { baseUrl, entries } objects.
+// baseUrl is the directory URL (no trailing slash, no /.DS_Store suffix).
+// entries is the sorted string[] of filenames parsed from that level's .DS_Store.
+//
+// The stack lets the Back button re-render previous levels without re-fetching.
+
+let dssStack = [];
+
+// Open the overlay and fetch the root-level .DS_Store for the given site URL.
+async function openDsStoreBrowser(siteUrl) {
+    dssStack = [];
+
+    const overlay  = document.getElementById("dss-overlay");
+    const listEl   = document.getElementById("dss-list");
+    const statusEl = document.getElementById("dss-status");
+    const pathEl   = document.getElementById("dss-path");
+
+    // Apply the user's chosen colour theme to the overlay nav (mirrors main nav init)
+    chrome.storage.local.get(["options"], function (result) {
+        if (result.options && result.options.color) {
+            const navWrapper = document.querySelector("#dss-nav .nav-wrapper");
+            if (navWrapper && !navWrapper.classList.contains(result.options.color)) {
+                navWrapper.classList.add(result.options.color);
+            }
+        }
+    });
+
+    // Show overlay in loading state
+    listEl.innerHTML = '';
+    statusEl.style.display = "block";
+    statusEl.textContent = "Loading...";
+    pathEl.textContent = siteUrl;
+    pathEl.title = siteUrl + "/.DS_Store";
+    document.getElementById("dss-back-li").style.display = "none";
+    overlay.style.display = "flex";
+
+    await dssNavigateTo(siteUrl);
+}
+
+// Fetch, parse, and display the .DS_Store at baseUrl/.DS_Store.
+// Pushes the result onto dssStack and renders the entry list.
+async function dssNavigateTo(baseUrl) {
+    // Ensure overlay is visible before navigation
+    const overlay = document.getElementById("dss-overlay");
+    if (overlay && overlay.style.display !== "flex") {
+        overlay.style.display = "flex";
+    }
+
+    const dsUrl    = baseUrl + "/.DS_Store";
+    const statusEl = document.getElementById("dss-status");
+    const listEl   = document.getElementById("dss-list");
+    const pathEl   = document.getElementById("dss-path");
+    const backEl   = document.getElementById("dss-back");
+
+    // Fallback: if any element is missing, abort navigation
+    if (!statusEl || !listEl || !pathEl || !backEl) {
+        debugLog("dssNavigateTo: Overlay or children missing, aborting navigation", { statusEl, listEl, pathEl, backEl });
+        return;
+    }
+
+    listEl.innerHTML = '';
+    statusEl.style.display = "block";
+    statusEl.textContent = "Fetching\u2026";
+    pathEl.textContent = baseUrl;
+    pathEl.title = dsUrl;
+
+    let entries;
+    try {
+        const response = await fetch(dsUrl, { redirect: "manual" });
+        if (response.status !== 200) {
+            throw new Error("HTTP " + response.status);
+        }
+        const buffer = await response.arrayBuffer();
+        entries = parseDSStore(buffer);
+    } catch (e) {
+        statusEl.textContent = "Error: " + e.message;
+        return;
+    }
+
+    if (entries.length === 0) {
+        statusEl.textContent = "No entries found in .DS_Store.";
+        return;
+    }
+
+    // Push this level onto the navigation stack
+    dssStack.push({ baseUrl, entries });
+
+    // Show the Back button once we have at least two levels
+    if (dssStack.length > 1) {
+        document.getElementById("dss-back-li").style.display = "";
+    }
+
+    statusEl.style.display = "none";
+    dssRenderEntries(baseUrl, entries, listEl);
+}
+
+// Render the file list for a given directory level.
+function dssRenderEntries(baseUrl, entries, listEl) {
+    listEl.innerHTML = '';
+
+    const itemPairs = entries.map(name => {
+        const li = document.createElement("li");
+        li.setAttribute("class", "collection-item dss-entry dss-loading");
+
+        const icon = document.createElement("i");
+        icon.setAttribute("class", "material-icons");
+        icon.textContent = "folder";           // default; updated after probe
+
+        const label = document.createElement("span");
+        label.textContent = name;
+
+        li.appendChild(icon);
+        li.appendChild(label);
+        listEl.appendChild(li);
+        return { li, icon, label, name };
+    });
+
+    // Probe all entries for nested .DS_Store files in parallel
+    itemPairs.forEach(({ li, icon, label, name }) => {
+        dssProbeEntry(baseUrl, name).then(browsable => {
+            li.classList.remove("dss-loading");
+
+            if (browsable) {
+                // Browsable directory: navigates on click
+                li.classList.add("dss-browsable");
+                icon.textContent = "folder_open";
+                li.addEventListener("click", () => {
+                    dssNavigateTo(baseUrl + "/" + encodeURIComponent(name));
+                });
+            } else {
+                // Non-browsable: clicking opens the URL as a link
+                li.classList.add("dss-grey");
+                // Guess icon: entries with a file extension get a file icon
+                const hasExtension = /\.[^./]+$/.test(name);
+                icon.textContent = hasExtension ? "insert_drive_file" : "folder";
+
+                // Wrap in an anchor so the URL opens in a new tab
+                const a = document.createElement("a");
+                a.href = baseUrl + "/" + encodeURIComponent(name);
+                a.textContent = name;
+                label.textContent = "";
+                label.appendChild(a);
+            }
+        });
+    });
+}
+
+// Returns true if baseUrl/name/.DS_Store exists and passes validation.
+async function dssProbeEntry(baseUrl, name) {
+    const probeUrl = baseUrl + "/" + encodeURIComponent(name) + "/.DS_Store";
+    try {
+        const fetchOpts = { redirect: "manual" };
+        // AbortSignal.timeout is available in Chrome 103+ / Firefox 100+
+        if (typeof AbortSignal !== "undefined" && AbortSignal.timeout) {
+            fetchOpts.signal = AbortSignal.timeout(8000);
+        }
+        const response = await fetch(probeUrl, fetchOpts);
+        if (response.status !== 200) return false;
+
+        const buf = await response.arrayBuffer();
+        if (buf.byteLength < 8) return false;
+
+        const view = new DataView(buf);
+        if (view.getUint32(0, false) !== 0x00000001) return false;
+        const b = new Uint8Array(buf, 4, 4);
+        // "Bud1" = 0x42 0x75 0x64 0x31
+        return b[0] === 0x42 && b[1] === 0x75 && b[2] === 0x64 && b[3] === 0x31;
+    } catch (_) {
+        // Fail silently, likely network errors.
+        return false;
+    }
+}
+
+// Navigate back one level in the directory stack.
+function dssNavigateBack() {
+    if (dssStack.length <= 1) return;
+
+    // Always show overlay before navigation
+    const overlay = document.getElementById("dss-overlay");
+    if (overlay) overlay.style.display = "flex";
+
+    dssStack.pop();  // discard current level
+    const prev     = dssStack[dssStack.length - 1];
+    const listEl   = document.getElementById("dss-list");
+    const pathEl   = document.getElementById("dss-path");
+    const statusEl = document.getElementById("dss-status");
+
+    pathEl.textContent = prev.baseUrl;
+    pathEl.title = prev.baseUrl + "/.DS_Store";
+    statusEl.style.display = "none";
+    listEl.innerHTML = '';
+    dssRenderEntries(prev.baseUrl, prev.entries, listEl);
+
+    if (dssStack.length <= 1) {
+        document.getElementById("dss-back-li").style.display = "none";
+    }
+}
+
+// Close the overlay and reset state.
+function dssClose() {
+    dssStack = [];
+    const overlay  = document.getElementById("dss-overlay");
+    const listEl   = document.getElementById("dss-list");
+    const statusEl = document.getElementById("dss-status");
+
+    overlay.style.display = "none";
+    listEl.innerHTML = '';
+    statusEl.style.display = "none";
+    statusEl.textContent = "Loading...";
+    document.getElementById("dss-back-li").style.display = "none";
+}

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -409,6 +409,10 @@ function dssOpenEntryInBackground(url) {
     window.open(url, "_blank", "noopener,noreferrer");
 }
 
+function dssIsBackgroundOpenEvent(event) {
+    return event.button === 1 || event.ctrlKey || event.metaKey;
+}
+
 // Open the overlay and fetch the root-level .DS_Store for the given site URL.
 async function openDsStoreBrowser(siteUrl) {
     dssStack = [];
@@ -523,8 +527,19 @@ function dssRenderEntries(baseUrl, entries, listEl) {
                 // Browsable directory: navigates on click
                 li.classList.add("dss-browsable");
                 icon.textContent = "folder_open";
-                li.addEventListener("click", () => {
+                li.setAttribute("title", "Click to browse, Ctrl/Cmd-click or middle-click to open in a background tab");
+
+                li.addEventListener("click", (event) => {
+                    if (dssIsBackgroundOpenEvent(event)) {
+                        dssOpenEntryInBackground(baseUrl + "/" + encodeURIComponent(name));
+                        return;
+                    }
                     dssNavigateTo(baseUrl + "/" + encodeURIComponent(name));
+                });
+                li.addEventListener("auxclick", (event) => {
+                    if (event.button !== 1) return;
+                    event.preventDefault();
+                    dssOpenEntryInBackground(baseUrl + "/" + encodeURIComponent(name));
                 });
             } else {
                 // Non-browsable: clicking opens the URL in a background tab.

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -397,6 +397,18 @@ document.addEventListener("DOMContentLoaded", async function () {
 
 let dssStack = [];
 
+function dssSetBackVisibility() {
+    document.getElementById("dss-back-li").style.display = dssStack.length > 1 ? "" : "none";
+}
+
+function dssOpenEntryInBackground(url) {
+    if (chrome.tabs && chrome.tabs.create) {
+        chrome.tabs.create({ url, active: false });
+        return;
+    }
+    window.open(url, "_blank", "noopener,noreferrer");
+}
+
 // Open the overlay and fetch the root-level .DS_Store for the given site URL.
 async function openDsStoreBrowser(siteUrl) {
     dssStack = [];
@@ -422,7 +434,7 @@ async function openDsStoreBrowser(siteUrl) {
     statusEl.textContent = "Loading...";
     pathEl.textContent = siteUrl;
     pathEl.title = siteUrl + "/.DS_Store";
-    document.getElementById("dss-back-li").style.display = "none";
+    dssSetBackVisibility();
     overlay.style.display = "flex";
 
     await dssNavigateTo(siteUrl);
@@ -468,17 +480,13 @@ async function dssNavigateTo(baseUrl) {
         return;
     }
 
+    // Push this level onto the navigation stack
+    dssStack.push({ baseUrl, entries });
+    dssSetBackVisibility();
+
     if (entries.length === 0) {
         statusEl.textContent = "No entries found in .DS_Store.";
         return;
-    }
-
-    // Push this level onto the navigation stack
-    dssStack.push({ baseUrl, entries });
-
-    // Show the Back button once we have at least two levels
-    if (dssStack.length > 1) {
-        document.getElementById("dss-back-li").style.display = "";
     }
 
     statusEl.style.display = "none";
@@ -519,18 +527,19 @@ function dssRenderEntries(baseUrl, entries, listEl) {
                     dssNavigateTo(baseUrl + "/" + encodeURIComponent(name));
                 });
             } else {
-                // Non-browsable: clicking opens the URL as a link
+                // Non-browsable: clicking opens the URL in a background tab.
                 li.classList.add("dss-grey");
+                li.setAttribute("title", "Open in a background tab");
+
+                const entryUrl = baseUrl + "/" + encodeURIComponent(name);
+
+                li.addEventListener("click", () => {
+                    dssOpenEntryInBackground(entryUrl);
+                });
+
                 // Guess icon: entries with a file extension get a file icon
                 const hasExtension = /\.[^./]+$/.test(name);
                 icon.textContent = hasExtension ? "insert_drive_file" : "folder";
-
-                // Wrap in an anchor so the URL opens in a new tab
-                const a = document.createElement("a");
-                a.href = baseUrl + "/" + encodeURIComponent(name);
-                a.textContent = name;
-                label.textContent = "";
-                label.appendChild(a);
             }
         });
     });
@@ -582,9 +591,7 @@ function dssNavigateBack() {
     listEl.innerHTML = '';
     dssRenderEntries(prev.baseUrl, prev.entries, listEl);
 
-    if (dssStack.length <= 1) {
-        document.getElementById("dss-back-li").style.display = "none";
-    }
+    dssSetBackVisibility();
 }
 
 // Close the overlay and reset state.
@@ -598,5 +605,5 @@ function dssClose() {
     listEl.innerHTML = '';
     statusEl.style.display = "none";
     statusEl.textContent = "Loading...";
-    document.getElementById("dss-back-li").style.display = "none";
+    dssSetBackVisibility();
 }


### PR DESCRIPTION
Hello! This PR adds a new functionality to .DS_Store files allowing you to parse .DS_Store files directly and browse the contents of files exposed through .DS_Store metadata. 

<img width="398" height="406" alt="image" src="https://github.com/user-attachments/assets/60f77e6d-bfc0-4734-b3ed-cd4f5337cda1" />

When a page has a .DS_Store detection, a new button is added which opens that file browser in the above screenshot. 

<img width="390" height="48" alt="image" src="https://github.com/user-attachments/assets/63ae0329-3a06-43da-b1a3-d538a4201414" />

I chose green to differentiate from the git download button, although if you want uniformity, this button can match the color of the download action button.

Internally, this downloads the .DS_Store file and any nested .DS_Store files when the browse option is opened, since macOS does not create a complete list of every file in a .DS_Store, it's hard to predict whether or not it will reveal anything, although from my testing from past finds, it seems to reveal a lot on some websites and little on others.

On the topic of AI usage, I like to be transparent and mention that I wrote the initial code and methodology by hand, and then used Claude code to help debug and fix some typos in the parser. Everything was tested by me and I don't "prompt and pray" as some have called it. 